### PR TITLE
Fix github links.

### DIFF
--- a/_posts/shared-string-resource.md
+++ b/_posts/shared-string-resource.md
@@ -56,7 +56,7 @@ For situation when there is a need for custom data post-processing, **the best w
 plugin** and implement any processing specifically to the project needs.
 
 For anyone interested in implementation details,
-check [my GitHub repository custom PoEditor Android plugin implementation](https://github.com/kotoMJ/kotox-android/blob/main/build-logic/README-POEDITOR.md)
+check [my GitHub repository custom PoEditor Android plugin implementation](https://github.com/mjDevCz/kotox-android/blob/main/build-logic/README-POEDITOR.md)
 
 ## Why using gradle plugin at all?
 

--- a/basics.md
+++ b/basics.md
@@ -4,7 +4,7 @@ Local first time:
 1) At the very first run: `npm install`
 
 Local any dev session:
-1) Run: `next` which will start pages locally and will automatically update any changes. Just reload page to see it.
+1) Run: `rm -rf .next && npm run dev` which will clear the cache and start pages locally. It will automatically update any changes. Just reload page to see it.
 
 
 Remote server (e.g. rosti) first time

--- a/components/socials-view.tsx
+++ b/components/socials-view.tsx
@@ -15,7 +15,7 @@ const SocialsView = (preview) => {
                 <a href={`mailto:jenicek.michal@gmail.com`}>
                     <img src="/assets/blog/social/email.png" className="w-10 h-10 p2 mr-4" alt=""/>
                 </a>
-                <a href={`https://github.com/kotoMJ`} target="_blank">
+                <a href={`https://github.com/mjDevCz`} target="_blank">
                     <img src="/assets/blog/social/github.png" className="w-10 h-10 p2 mr-4" alt=""/>
                 </a>
                 <a href={`https://www.linkedin.com/in/jenicekmichal/`} target="_blank">


### PR DESCRIPTION
## Summary
- Update GitHub links from `kotoMJ` to `mjDevCz` in article and socials component
- Fix local dev command in basics.md to use `rm -rf .next && npm run dev` instead of bare `next`

## Test plan
- [ ] Verify GitHub links in the article and footer point to the correct profile
- [ ] Verify `rm -rf .next && npm run dev` starts the dev server correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)