### PR TITLE
Fix code snippet styling on mobile

### DIFF
--- a/components/markdown-styles.module.css
+++ b/components/markdown-styles.module.css
@@ -37,6 +37,21 @@
     @apply ml-8 list-disc
 }
 
+.markdown code {
+    @apply px-1.5 py-0.5 rounded bg-gray-100 text-gray-800;
+    font-size: 0.875em;
+}
+
+.markdown pre {
+    @apply my-6 p-4 rounded-lg bg-gray-100 text-sm leading-normal overflow-x-auto;
+}
+
+.markdown pre code {
+    @apply p-0 bg-transparent text-gray-800;
+    font-size: inherit;
+    white-space: pre;
+}
+
 .markdown img {
     @apply block w-full my-8 rounded-lg;
 }


### PR DESCRIPTION
## Summary

Adds explicit styling for inline `code`, `pre` blocks, and code inside `pre` in the markdown styles so code snippets render correctly on mobile.

- Inline `code` gets padding, rounded corners, a light gray background, and a slightly smaller font size.
- `pre` blocks get spacing, padding, rounded corners, a gray background, and `overflow-x-auto` so long lines scroll horizontally instead of overflowing the viewport on small screens.
- `pre code` resets the inline-code styling (no extra padding/background) and preserves whitespace with `white-space: pre`.

## Why

Previously code snippets could overflow the viewport on mobile. The `overflow-x-auto` on `pre` keeps wide code contained and horizontally scrollable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)