### PR TITLE
Copy edits for Part 2: Two writes for every tap

### DIFF
--- a/_posts/offline-first-two-writes.md
+++ b/_posts/offline-first-two-writes.md
@@ -23,13 +23,13 @@ is online or off.
 
 ## The Problem With "Just Sync It"
 
-In Part 1 I picked PowerSync and hand-waved the hard part: choosing a sync engine is the easy 20%. The
+In [Part 1](/posts/offline-first-kmp) I picked **PowerSync** and hand-waved the hard part: choosing a sync engine is the easy 20%. The
 other 80% is deciding what your app writes, when, and what the user sees while the server hasn't heard
 about any of it yet.
 
 Here's the constraint that shapes everything. Our users are cellar hands: people moving wine between
-tanks, recording intake at the crush pad, blending, bottling. Half the time they're standing in a
-metal shed with no signal. When someone taps "move this wine to Tank 7," the app cannot wait for a
+tanks, recording intake at the crush pad, blending, bottling. Half the time they're down in the
+cellar with no signal. When someone taps "move this wine to Tank 7," the app cannot wait for a
 server to agree. The screen has to update *now*, on a device that might not reconnect for hours.
 
 So the naive model (tap, send request, wait, update UI) is dead on arrival. What replaces it is a
@@ -54,7 +54,7 @@ The reason it's an *event* and not a *state update* is a whole topic of its own,
 here to keep this post about the mechanics. For now the takeaway is enough: we write down what the user
 did, not what we think the world now looks like.
 
-## Write #2: The Projection (What It Means, Provisionally)
+## Write #2: The Projection (What You See)
 
 But an event log doesn't render a screen. The user doesn't want to see "you recorded a transfer event."
 They want to see wine X sitting in Tank 7, right now, with the right volume.

--- a/_posts/offline-first-two-writes.md
+++ b/_posts/offline-first-two-writes.md
@@ -91,9 +91,15 @@ The first reaction is always "so I'm writing data I'm going to throw away?" Yes.
 projection is a provisional answer: a bet that the server will agree. When the server's version syncs
 back, it replaces your local guess.
 
-And the beautiful part, the part that made me trust this architecture, is that *you write no cleanup
-code for this.* You don't diff, you don't reconcile, you don't delete your optimistic row when the real
-one arrives. The sync layer does it for you, through a mechanism I'll unpack in Part 4.
+The reason this is safe, the part that made me trust this architecture, is that the projection is
+disposable *by construction*: the event it came from is permanent. It's an append-only fact that never
+gets edited or deleted, so the projection is always re-derivable from it. Throwing away the local guess
+costs nothing, because nothing was ever really *stored* there — the truth lives in the event log, and
+the projection is just the log read out loud.
+
+And *because* the projection is re-derivable, you don't even write the reconciliation. You don't diff,
+you don't delete your optimistic row when the real one arrives. The sync layer reverts your local guess
+when the authoritative row syncs down, through a mechanism I'll unpack in Part 4.
 
 ## Why Split It This Way
 
@@ -101,8 +107,8 @@ You could imagine collapsing the two writes into one: just update the entity tab
 of offline apps do exactly that. Here's what you lose.
 
 - **The event is the truth; the entity is a view.** If a projection is wrong (a bug, a bad assumption
-  about current state), you fix the projection logic and re-derive. The historical record of what the
-  user actually did is untouched. You never corrupt history to fix a display bug.
+  about current state), you fix the projection logic and re-derive. You correct the view, never the
+  history — a display bug never becomes a reason to rewrite what the user actually did.
 - **The server can be late without being wrong.** Because the client and server both derive state from
   the same events, "the device is ahead of the server" is a normal, expected condition, not a
   desync bug. The device shows its best guess; the server confirms or corrects; they converge.


### PR DESCRIPTION
## Summary

Editorial and content sync for the Part 2 blog post (`_posts/offline-first-two-writes.md`), bringing it in line with the canonical draft.

- Linked "Part 1" to `/posts/offline-first-kmp` and bolded **PowerSync**.
- Changed "standing in a metal shed" → "down in the cellar" (more evocative and consistent with "cellar hands").
- Retitled Write #2 heading to "The Projection (What You See)" to parallel Write #1's "(What Happened)".
- Reworked the closing paragraphs of *The Part That Feels Wrong* — projection is disposable *by construction*, and the reconciliation follows because it's re-derivable.
- Reworded the first bullet in *Why Split It This Way* ("You correct the view, never the history…").

🤖 Generated with [Claude Code](https://claude.com/claude-code)