### PR TITLE
Add series showcase bands to the homepage

### DIFF
--- a/components/series-showcase.tsx
+++ b/components/series-showcase.tsx
@@ -1,0 +1,56 @@
+import Link from 'next/link'
+import DateFormatter from './date-formatter'
+import type { SeriesShowcase as SeriesShowcaseData } from '../lib/api'
+
+type Props = {
+  series: SeriesShowcaseData
+}
+
+// A subtle, self-contained band that spotlights an ongoing series on the
+// homepage: series title, a short blurb, and its parts laid out as a numbered
+// row. Sits between the hero and the "More Stories" grid.
+const SeriesShowcase = ({ series }: Props) => {
+  const { name, description, parts } = series
+  if (parts.length === 0) return null
+
+  return (
+    <section className="mb-20 md:mb-28">
+      <div className="rounded-lg border border-gray-200 bg-gray-50 p-8 md:p-12">
+        <p className="uppercase tracking-widest font-semibold text-gray-500 text-sm mb-3">
+          Series · {parts.length} {parts.length === 1 ? 'part' : 'parts'}
+        </p>
+        <h2 className="text-3xl md:text-4xl font-bold tracking-tighter leading-tight mb-3">
+          {name}
+        </h2>
+        {description && (
+          <p className="text-lg leading-relaxed text-gray-700 mb-8 max-w-3xl">{description}</p>
+        )}
+        <ol className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {parts.map((part) => (
+            <li key={part.slug}>
+              <Link
+                as={`/posts/${part.slug}`}
+                href="/posts/[slug]"
+                className="group flex gap-4 no-underline"
+              >
+                <span className="flex-shrink-0 flex items-center justify-center w-9 h-9 rounded-full border border-gray-300 bg-white text-sm font-semibold text-gray-600">
+                  {part.part ?? '·'}
+                </span>
+                <span className="block">
+                  <span className="block text-lg leading-snug group-hover:underline">
+                    {part.title}
+                  </span>
+                  <span className="block text-sm text-gray-500 mt-1">
+                    <DateFormatter dateString={part.date} />
+                  </span>
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  )
+}
+
+export default SeriesShowcase

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -75,6 +75,65 @@ export function getSeriesNav(slug: string): {
   }
 }
 
+export type SeriesShowcasePart = {
+  slug: string
+  title: string
+  part: number | null
+  date: string
+}
+
+export type SeriesShowcase = {
+  name: string
+  description: string
+  parts: SeriesShowcasePart[]
+}
+
+// How many series bands the homepage will show at once, newest-active first.
+export const MAX_FEATURED_SERIES = 3
+
+// Series to feature on the homepage, ordered by recency (the series whose newest
+// part is most recent comes first), capped at MAX_FEATURED_SERIES. Each series'
+// parts are ordered by `seriesPart`, with a short description from the first
+// part's excerpt. Empty when no post has a series.
+export function getFeaturedSeries(): SeriesShowcase[] {
+  const posts = getAllPosts(['slug', 'title', 'series', 'seriesPart', 'date', 'excerpt'])
+
+  // `posts` is date-descending, so first sighting of a series name = its newest
+  // part. Collecting names in encounter order gives us newest-active first.
+  const order: string[] = []
+  const groups: Record<string, typeof posts> = {}
+  for (const p of posts) {
+    const name = p.series as string | undefined
+    if (!name) continue
+    if (!groups[name]) {
+      groups[name] = []
+      order.push(name)
+    }
+    groups[name].push(p)
+  }
+
+  return order
+    // Only feature a series once it has at least two published parts; a lone
+    // Part 1 stays an ordinary card in the grid until Part 2 ships.
+    .filter((name) => groups[name].length >= 2)
+    .slice(0, MAX_FEATURED_SERIES)
+    .map((name) => {
+      const parts = groups[name]
+        .slice()
+        .sort((a, b) => Number(a.seriesPart ?? 0) - Number(b.seriesPart ?? 0))
+      return {
+        name,
+        description: (parts[0]?.excerpt as string) ?? '',
+        parts: parts.map((p) => ({
+          slug: p.slug as string,
+          title: p.title as string,
+          part: p.seriesPart != null ? Number(p.seriesPart) : null,
+          date: p.date as string,
+        })),
+      }
+    })
+}
+
 export function getAllPosts(fields: string[] = []) {
     const slugs = getPostSlugs()
     const posts = slugs

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,11 @@
 import Container from '../components/container'
 import MoreStories from '../components/more-stories'
 import HeroPost from '../components/hero-post'
+import SeriesShowcase from '../components/series-showcase'
 import Intro from '../components/intro'
 import Layout from '../components/layout'
-import {getAllPosts} from '../lib/api'
+import {getAllPosts, getFeaturedSeries} from '../lib/api'
+import type {SeriesShowcase as SeriesShowcaseData} from '../lib/api'
 import {getCoverBlurDataURL} from '../lib/coverBlur'
 import {generateRssFeed} from '../lib/generateRssFeed'
 import fs from 'fs'
@@ -12,11 +14,15 @@ import Post from '../interfaces/post'
 
 type Props = {
     allPosts: Post[]
+    featuredSeries: SeriesShowcaseData[]
 }
 
-export default function Index({allPosts}: Props) {
+export default function Index({allPosts, featuredSeries}: Props) {
     const heroPost = allPosts[0]
-    const morePosts = allPosts.slice(1)
+    // Parts shown in a series band are dropped from the grid so a post never
+    // appears twice (the hero is intentionally left as-is).
+    const featuredSlugs = new Set(featuredSeries.flatMap((s) => s.parts.map((p) => p.slug)))
+    const morePosts = allPosts.slice(1).filter((p) => !featuredSlugs.has(p.slug))
     return (
         <>
             <Layout>
@@ -38,6 +44,9 @@ export default function Index({allPosts}: Props) {
                             excerpt={heroPost.excerpt}
                         />
                     )}
+                    {featuredSeries.map((series) => (
+                        <SeriesShowcase key={series.name} series={series}/>
+                    ))}
                     {morePosts.length > 0 && <MoreStories posts={morePosts}/>}
                 </Container>
             </Layout>
@@ -67,6 +76,6 @@ export const getStaticProps = async () => {
     fs.writeFileSync('public/feed.xml', await generateRssFeed())
 
     return {
-        props: {allPosts: allPostsWithBlur},
+        props: {allPosts: allPostsWithBlur, featuredSeries: getFeaturedSeries()},
     }
 }


### PR DESCRIPTION
## Summary

Makes multi-part series **clearly visible on the dashboard**. Each series is grouped into a subtle, self-contained band placed between the hero and the "More Stories" grid, so a series reads as one unit instead of scattering across the feed.

- **`getFeaturedSeries()`** (`lib/api.ts`) now returns a list of series:
  - ordered **newest-active first** (the series whose latest part is most recent),
  - capped at `MAX_FEATURED_SERIES` (3),
  - only featured once a series has **≥ 2 published parts** (a lone Part 1 stays an ordinary grid card until Part 2 ships).
- **Homepage** (`pages/index.tsx`) renders one `<SeriesShowcase>` band per series and **drops banded posts from the grid**, so no post appears twice. The hero is intentionally left as-is (newest post), so it may also appear in its series band.
- **`components/series-showcase.tsx`** — subtle bordered/tinted card: series eyebrow, title, blurb (first part's excerpt), and the parts as a numbered row of links.

## Notes / knobs

- `MAX_FEATURED_SERIES` — change the cap, or set higher for no practical limit.
- The ≥2-parts filter runs before the cap, so single-part series don't consume a slot.

## Verification

- `tsc --noEmit` clean.
- Rendered locally: Part 1 appears only in the band (deduped from grid), Part 2 shows as hero + band, band renders before "More Stories".

🤖 Generated with [Claude Code](https://claude.com/claude-code)