### PR TITLE
Add shareable series overview pages

### DIFF
--- a/_posts/aboutme.md
+++ b/_posts/aboutme.md
@@ -1,6 +1,6 @@
 ---
 title: 'Michal Jeníček • MJ'
-excerpt: 'I am Michal (aka MJ) - a Software Engineer with over 10 years of Android experience as of 2026, crafting apps of all shapes and sizes at STRV.'
+excerpt: 'I am Michal (aka MJ) - a Software Engineer with over 10 years of Android experience as of 2026 - and a background in enterprise banking software - crafting apps of all shapes and sizes at STRV.'
 coverImage: '/assets/blog/about/cover-talk-brno.jpg'
 date: ''
 metaData:
@@ -15,7 +15,7 @@ hideReadingTime: true
 
 Hi there! I'm Michal, aka **MJ** — a Software Engineer based in Central Bohemia, Czechia.
 
-As of 2026, I have over **10 years of Android experience**, all of it at [STRV](https://www.strv.com/) — a software agency where the variety of projects never lets you get comfortable. Agency life means greenfield builds one quarter, legacy rewrites the next. Different domains, different scales, different user bases — and lately, **Kotlin Multiplatform (KMP)** in production. That range shaped how I think about mobile development.
+As of 2026, I have over **10 years of Android experience**, all of it at [STRV](https://www.strv.com/) — a software agency where the variety of projects never lets you get comfortable. My software engineering roots reach back a little further, though: before mobile, I cut my teeth building enterprise applications for banking, where correctness and reliability were never negotiable. Agency life since then has meant greenfield builds one quarter, legacy rewrites the next. Different domains, different scales, different user bases — and lately, **Kotlin Multiplatform (KMP)** in production. That range shaped how I think about mobile development.
 
 ## Projects that became part of my journey
 

--- a/_posts/aboutme.md
+++ b/_posts/aboutme.md
@@ -15,7 +15,7 @@ hideReadingTime: true
 
 Hi there! I'm Michal, aka **MJ** — a Software Engineer based in Central Bohemia, Czechia.
 
-As of 2026, I have over **10 years of Android experience**, all of it at [STRV](https://www.strv.com/) — a software agency where the variety of projects never lets you get comfortable. My software engineering roots reach back a little further, though: before mobile, I cut my teeth building enterprise applications for banking, where correctness and reliability were never negotiable. Agency life since then has meant greenfield builds one quarter, legacy rewrites the next. Different domains, different scales, different user bases — and lately, **Kotlin Multiplatform (KMP)** in production. That range shaped how I think about mobile development.
+As of 2026, I have over **10 years of Android experience**, all of it at [STRV](https://www.strv.com/) — a software agency where the variety of projects never lets you get comfortable. My software engineering roots reach back a little further, though: before mobile, I cut my teeth building enterprise [applications for banking](https://www.kb.cz/en/our-applications), where correctness and reliability were never negotiable. Agency life since then has meant greenfield builds one quarter, legacy rewrites the next. Different domains, different scales, different user bases — and lately, **Kotlin Multiplatform (KMP)** in production. That range shaped how I think about mobile development.
 
 ## Projects that became part of my journey
 

--- a/components/series-label.tsx
+++ b/components/series-label.tsx
@@ -1,3 +1,6 @@
+import Link from 'next/link'
+import {seriesSlug} from '../lib/series'
+
 type Props = {
   series?: string
   part?: number
@@ -5,12 +8,15 @@ type Props = {
 }
 
 // Small uppercase "eyebrow" shown above a post title to mark it as part of a
-// series, e.g. "Offline-First KMP · Part 2".
+// series, e.g. "Offline-First KMP · Part 2". The series name links to the
+// series overview page so readers can reach the full list from any part.
 const SeriesLabel = ({ series, part, className = '' }: Props) => {
   if (!series) return null
   return (
     <p className={`uppercase tracking-widest font-semibold text-gray-500 ${className}`}>
-      {series}
+      <Link href="/series/[slug]" as={`/series/${seriesSlug(series)}`} className="hover:underline">
+        {series}
+      </Link>
       {part ? ` · Part ${part}` : ''}
     </p>
   )

--- a/components/series-showcase.tsx
+++ b/components/series-showcase.tsx
@@ -10,7 +10,7 @@ type Props = {
 // homepage: series title, a short blurb, and its parts laid out as a numbered
 // row. Sits between the hero and the "More Stories" grid.
 const SeriesShowcase = ({ series }: Props) => {
-  const { name, description, parts } = series
+  const { name, slug, description, parts } = series
   if (parts.length === 0) return null
 
   return (
@@ -20,7 +20,9 @@ const SeriesShowcase = ({ series }: Props) => {
           Series · {parts.length} {parts.length === 1 ? 'part' : 'parts'}
         </p>
         <h2 className="text-3xl md:text-4xl font-bold tracking-tighter leading-tight mb-3">
-          {name}
+          <Link href="/series/[slug]" as={`/series/${slug}`} className="hover:underline">
+            {name}
+          </Link>
         </h2>
         {description && (
           <p className="text-lg leading-relaxed text-gray-700 mb-8 max-w-3xl">{description}</p>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,6 +1,9 @@
 import fs from 'fs'
 import {join} from 'path'
 import matter from 'gray-matter'
+import {seriesSlug} from './series'
+
+export {seriesSlug}
 
 const postsDirectory = join(process.cwd(), '_posts')
 
@@ -84,6 +87,7 @@ export type SeriesShowcasePart = {
 
 export type SeriesShowcase = {
   name: string
+  slug: string
   description: string
   parts: SeriesShowcasePart[]
 }
@@ -91,11 +95,11 @@ export type SeriesShowcase = {
 // How many series bands the homepage will show at once, newest-active first.
 export const MAX_FEATURED_SERIES = 3
 
-// Series to feature on the homepage, ordered by recency (the series whose newest
-// part is most recent comes first), capped at MAX_FEATURED_SERIES. Each series'
-// parts are ordered by `seriesPart`, with a short description from the first
-// part's excerpt. Empty when no post has a series.
-export function getFeaturedSeries(): SeriesShowcase[] {
+// All series that have at least one post, ordered by recency (the series whose
+// newest part is most recent comes first). Each series' parts are ordered by
+// `seriesPart`, with a short description from the first part's excerpt. This is
+// the shared source for both the homepage bands and the /series overview pages.
+export function getAllSeries(): SeriesShowcase[] {
   const posts = getAllPosts(['slug', 'title', 'series', 'seriesPart', 'date', 'excerpt'])
 
   // `posts` is date-descending, so first sighting of a series name = its newest
@@ -112,26 +116,36 @@ export function getFeaturedSeries(): SeriesShowcase[] {
     groups[name].push(p)
   }
 
-  return order
-    // Only feature a series once it has at least two published parts; a lone
-    // Part 1 stays an ordinary card in the grid until Part 2 ships.
-    .filter((name) => groups[name].length >= 2)
+  return order.map((name) => {
+    const parts = groups[name]
+      .slice()
+      .sort((a, b) => Number(a.seriesPart ?? 0) - Number(b.seriesPart ?? 0))
+    return {
+      name,
+      slug: seriesSlug(name),
+      description: (parts[0]?.excerpt as string) ?? '',
+      parts: parts.map((p) => ({
+        slug: p.slug as string,
+        title: p.title as string,
+        part: p.seriesPart != null ? Number(p.seriesPart) : null,
+        date: p.date as string,
+      })),
+    }
+  })
+}
+
+// Look up a single series by its slug for the /series/[slug] page.
+export function getSeriesBySlug(slug: string): SeriesShowcase | null {
+  return getAllSeries().find((s) => s.slug === slug) ?? null
+}
+
+// Series to feature on the homepage, ordered by recency, capped at
+// MAX_FEATURED_SERIES. Only series with at least two published parts are
+// featured; a lone Part 1 stays an ordinary card in the grid until Part 2 ships.
+export function getFeaturedSeries(): SeriesShowcase[] {
+  return getAllSeries()
+    .filter((s) => s.parts.length >= 2)
     .slice(0, MAX_FEATURED_SERIES)
-    .map((name) => {
-      const parts = groups[name]
-        .slice()
-        .sort((a, b) => Number(a.seriesPart ?? 0) - Number(b.seriesPart ?? 0))
-      return {
-        name,
-        description: (parts[0]?.excerpt as string) ?? '',
-        parts: parts.map((p) => ({
-          slug: p.slug as string,
-          title: p.title as string,
-          part: p.seriesPart != null ? Number(p.seriesPart) : null,
-          date: p.date as string,
-        })),
-      }
-    })
 }
 
 export function getAllPosts(fields: string[] = []) {

--- a/lib/series.ts
+++ b/lib/series.ts
@@ -1,0 +1,9 @@
+// Turn a series name into a URL-friendly slug, e.g. 'Offline-First KMP' ->
+// 'offline-first-kmp'. Kept free of server-only imports (no `fs`) so it can be
+// used from client components as well as the build-time API in `lib/api.ts`.
+export function seriesSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}

--- a/pages/series/[slug].tsx
+++ b/pages/series/[slug].tsx
@@ -1,0 +1,105 @@
+import {useRouter} from 'next/router'
+import ErrorPage from 'next/error'
+import Link from 'next/link'
+import Head from 'next/head'
+import Container from '../../components/container'
+import Header from '../../components/header'
+import Layout from '../../components/layout'
+import PostTitle from '../../components/post-title'
+import DateFormatter from '../../components/date-formatter'
+import {getAllSeries, getSeriesBySlug} from '../../lib/api'
+import type {SeriesShowcase} from '../../lib/api'
+import {CMS_DOMAIN, CMS_INTRO} from '../../lib/constants'
+
+type Props = {
+    series: SeriesShowcase | null
+}
+
+export default function SeriesPage({series}: Props) {
+    const router = useRouter()
+    if (!router.isFallback && !series) {
+        return <ErrorPage statusCode={404}/>
+    }
+    return (
+        <Layout>
+            <Container>
+                <Header/>
+                {router.isFallback || !series ? (
+                    <PostTitle>Loading…</PostTitle>
+                ) : (
+                    <article className="mb-32">
+                        <Head>
+                            <title>
+                                {series.name} | {CMS_INTRO}
+                            </title>
+                            <meta property="og:title" content={series.name}/>
+                            <meta property="og:description" content={series.description}/>
+                            <meta property="og:type" content="website"/>
+                            <meta property="og:url" content={CMS_DOMAIN + '/series/' + series.slug}/>
+                            <meta name="twitter:title" content={series.name}/>
+                            <meta name="twitter:description" content={series.description}/>
+                            <meta name="twitter:card" content="summary"/>
+                        </Head>
+                        <p className="uppercase tracking-widest font-semibold text-gray-500 text-sm mb-4">
+                            Series · {series.parts.length} {series.parts.length === 1 ? 'part' : 'parts'}
+                        </p>
+                        <h1 className="text-4xl md:text-6xl font-bold tracking-tighter leading-tight mb-6">
+                            {series.name}
+                        </h1>
+                        {series.description && (
+                            <p className="text-lg md:text-xl leading-relaxed text-gray-700 mb-12 max-w-3xl">
+                                {series.description}
+                            </p>
+                        )}
+                        <ol className="max-w-3xl">
+                            {series.parts.map((part) => (
+                                <li key={part.slug} className="border-t border-gray-200 py-6">
+                                    <Link
+                                        as={`/posts/${part.slug}`}
+                                        href="/posts/[slug]"
+                                        className="group flex gap-5 no-underline"
+                                    >
+                                        <span className="flex-shrink-0 flex items-center justify-center w-11 h-11 rounded-full border border-gray-300 bg-white text-base font-semibold text-gray-600">
+                                            {part.part ?? '·'}
+                                        </span>
+                                        <span className="block">
+                                            <span className="block text-xl md:text-2xl font-semibold leading-snug group-hover:underline">
+                                                {part.title}
+                                            </span>
+                                            <span className="block text-sm text-gray-500 mt-1">
+                                                <DateFormatter dateString={part.date}/>
+                                            </span>
+                                        </span>
+                                    </Link>
+                                </li>
+                            ))}
+                        </ol>
+                    </article>
+                )}
+            </Container>
+        </Layout>
+    )
+}
+
+type Params = {
+    params: {
+        slug: string
+    }
+}
+
+export async function getStaticProps({params}: Params) {
+    return {
+        props: {
+            series: getSeriesBySlug(params.slug),
+        },
+    }
+}
+
+export async function getStaticPaths() {
+    return {
+        paths: getAllSeries().map((series) => ({
+            params: {slug: series.slug},
+        })),
+        fallback: false,
+    }
+}


### PR DESCRIPTION
## What

Adds a dedicated `/series/[slug]` route that presents a whole series as a single overview page — title, description, and every part in order — so the full series can be shared with one stable, shareable link (e.g. `/series/offline-first-kmp`), independent of whether the series is currently featured on the homepage.

Both existing entry points now link into it:
- The **homepage series band** title links to the overview.
- The **post eyebrow** (e.g. "Offline-First KMP · Part 2") — the series name links to the overview, so a reader landing mid-series can reach the full list from any part.

## Changes

- `lib/series.ts` (new) — `seriesSlug()` helper, free of server-only `fs` so it's safe to import from client components.
- `lib/api.ts` — new `getAllSeries()` / `getSeriesBySlug()`; `getFeaturedSeries()` now reuses `getAllSeries()` (same homepage behavior: ≥2 parts, capped at 3); `SeriesShowcase` gains a `slug`.
- `pages/series/[slug].tsx` (new) — statically-generated overview page with OG/Twitter meta.
- `components/series-showcase.tsx` — band title links to the overview.
- `components/series-label.tsx` — post eyebrow series name links to the overview.

## Notes

- A series page is generated for every series with at least one post; the homepage band and title link still only appear once a series has ≥2 parts (unchanged featuring rule).
- `tsc --noEmit` and `next build` both pass; `/series/offline-first-kmp` generates as a static page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)