### PR TITLE
Add TL;DR to Part 1 and link about-me to series overview

### DIFF
--- a/_posts/aboutme.md
+++ b/_posts/aboutme.md
@@ -29,7 +29,7 @@ Here are some of the projects I've had the privilege to work on as an Android En
 - **Opkix** — lightweight wearable camera & video editing
 - **LegalZoom** — legal services
 
-My latest ongoing work involves a [strongly offline-first KMP application](/posts/offline-first-kmp) — a challenge I particularly enjoy.
+My latest ongoing work involves a [strongly offline-first KMP application](/series/offline-first-kmp) — a challenge I particularly enjoy.
 
 ## What I believe in
 

--- a/_posts/offline-first-kmp.md
+++ b/_posts/offline-first-kmp.md
@@ -14,7 +14,7 @@ ogImage:
 ogTitle: "Choosing an offline-first sync layer for KMP"
 ---
 
-When your mobile app must work without internet as a **standard — not an edge case** — picking the right sync layer becomes the most critical architectural decision. This is the story of how we evaluated the offline-first landscape for a Kotlin Multiplatform project.
+**TL;DR** When your mobile app must work without internet as a **standard, not an edge case**, picking the right sync layer becomes the most critical architectural decision. This is the story of how we evaluated the offline-first landscape for a Kotlin Multiplatform (KMP) project.
 
 ## The requirements
 


### PR DESCRIPTION
## Summary
- Add a `**TL;DR**` block to the top of `offline-first-kmp.md` (Part 1), matching the style used in Part 2 (`offline-first-two-writes.md`). The near-duplicate intro paragraph was merged into it to avoid repeating the same sentence twice.
- Retarget the offline-first link in the about-me section to the series overview page `/series/offline-first-kmp` (previously pointed at the first post).

## Test plan
- [ ] Verify the TL;DR renders at the top of Part 1
- [ ] Verify the about-me link resolves to the series overview page

🤖 Generated with [Claude Code](https://claude.com/claude-code)