### PR TITLE
Declare og:image dimensions for reliable social previews

### DIFF
--- a/pages/series/[slug].tsx
+++ b/pages/series/[slug].tsx
@@ -11,15 +11,16 @@ import DateFormatter from '../../components/date-formatter'
 import CoverImage from '../../components/cover-image'
 import {getAllSeries, getSeriesBySlug} from '../../lib/api'
 import type {SeriesShowcase} from '../../lib/api'
-import {getCoverBlurDataURL} from '../../lib/coverBlur'
+import {getLocalImageMeta} from '../../lib/coverBlur'
+import type {LocalImageMeta} from '../../lib/coverBlur'
 import {CMS_DOMAIN, CMS_INTRO} from '../../lib/constants'
 
 type Props = {
     series: SeriesShowcase | null
-    coverBlurDataURL: string | null
+    coverMeta: LocalImageMeta | null
 }
 
-export default function SeriesPage({series, coverBlurDataURL}: Props) {
+export default function SeriesPage({series, coverMeta}: Props) {
     const router = useRouter()
     if (!router.isFallback && !series) {
         return <ErrorPage statusCode={404}/>
@@ -42,6 +43,21 @@ export default function SeriesPage({series, coverBlurDataURL}: Props) {
                             <meta property="og:url" content={CMS_DOMAIN + '/series/' + series.slug}/>
                             {series.cover && (
                                 <meta property="og:image" content={CMS_DOMAIN + series.cover}/>
+                            )}
+                            {series.cover && (
+                                <meta property="og:image:secure_url" content={CMS_DOMAIN + series.cover}/>
+                            )}
+                            {series.cover && (
+                                <meta property="og:image:type" content="image/jpeg"/>
+                            )}
+                            {coverMeta && (
+                                <meta property="og:image:width" content={String(coverMeta.width)}/>
+                            )}
+                            {coverMeta && (
+                                <meta property="og:image:height" content={String(coverMeta.height)}/>
+                            )}
+                            {series.cover && (
+                                <meta property="og:image:alt" content={`Cover image for ${series.name}`}/>
                             )}
                             <meta name="twitter:title" content={series.name}/>
                             <meta name="twitter:description" content={series.description}/>
@@ -66,7 +82,7 @@ export default function SeriesPage({series, coverBlurDataURL}: Props) {
                                 <CoverImage
                                     title={series.name}
                                     src={series.cover}
-                                    blurDataURL={coverBlurDataURL}
+                                    blurDataURL={coverMeta?.blurDataURL}
                                     priority
                                 />
                             </div>
@@ -120,11 +136,11 @@ type Params = {
 
 export async function getStaticProps({params}: Params) {
     const series = getSeriesBySlug(params.slug)
-    const coverBlurDataURL = series?.cover ? await getCoverBlurDataURL(series.cover) : null
+    const coverMeta = series?.cover ? await getLocalImageMeta(series.cover) : null
     return {
         props: {
             series,
-            coverBlurDataURL,
+            coverMeta,
         },
     }
 }


### PR DESCRIPTION
## Why

After #21 shipped the series banner + `og:image`, LinkedIn still rendered a **title-only card with no image**, even though the deployed page serves a valid `og:image` and the asset is reachable (HTTP 200, `image/jpeg`, 313 KB, 1920×1072 — above LinkedIn's 1200×627 minimum).

The cause is a well-known LinkedIn quirk: on first scrape it won't render an image it hasn't yet downloaded and measured. Declaring the image dimensions up front makes crawlers render the banner immediately instead of needing a second pass.

## Changes

- Read the cover's real dimensions via `getLocalImageMeta` (which also produces the blur placeholder in the same call, replacing the separate `getCoverBlurDataURL`).
- Emit the full image meta set on `/series/[slug]`: `og:image:width`, `og:image:height`, `og:image:secure_url`, `og:image:type`, and `og:image:alt`.

## Verification

- `tsc --noEmit` clean
- Confirmed on dev server: all six `og:image*` tags render with real dimensions (`width=1920`, `height=1072`), and the blur-up placeholder still works.

## After merge / deploy

Because LinkedIn caches by canonical URL, post a fresh cache-busting URL (e.g. `…/series/offline-first-kmp?v=3`) in a **new** post so it re-scrapes with the new tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)