### PR TITLE
Drop canonical og:url on series page to beat LinkedIn cache

### DIFF
--- a/pages/series/[slug].tsx
+++ b/pages/series/[slug].tsx
@@ -43,7 +43,15 @@ export default function SeriesPage({series, coverMeta, socialMeta}: Props) {
                             <meta property="og:type" content="website"/>
                             <meta property="og:site_name" content={CMS_INTRO}/>
                             <meta property="og:locale" content="en_US"/>
-                            <meta property="og:url" content={CMS_DOMAIN + '/series/' + series.slug}/>
+                            {/*
+                              Intentionally no canonical og:url. LinkedIn caches
+                              share previews keyed on og:url and canonicalizes
+                              query-string variants back to it, so a stale first
+                              scrape (before this page had an image) sticks and
+                              cache-busting URLs (?v=N) collapse to it. Omitting
+                              og:url makes LinkedIn key on the exact shared URL,
+                              so a fresh ?v= reliably forces a clean re-scrape.
+                            */}
                             {series.social && (
                                 <meta property="og:image" content={CMS_DOMAIN + series.social}/>
                             )}


### PR DESCRIPTION
## Why

The series overview page (`/series/offline-first-kmp`) previews with **no image on LinkedIn**, even though:
- The same tags render an image fine on **X** (proving the metadata + `og.jpg` are correct).
- A *different* URL on the same site — `/posts/offline-first-kmp` — also previews with its image.

The differentiator is LinkedIn's cache. LinkedIn keys share previews on **`og:url`** and canonicalizes query-string variants back to it. The series URL was first scraped *before it had an image*, so that imageless entry stuck — and every `?v=N` cache-buster collapsed back to it via `og:url`.

## Change

Remove the hardcoded canonical `og:url` from the series page (`pages/series/[slug].tsx`). LinkedIn then keys on the exact shared URL, so a fresh `?v=` reliably forces a clean re-scrape that picks up the 1200×630 `og.jpg`. A code comment documents why it's intentionally absent.

Trade-off: LinkedIn no longer consolidates share variants to one canonical URL — negligible for this blog, and `og:image`/`twitter:image`/canonical `<link>` behavior is otherwise unchanged.

## Verification

- `tsc --noEmit` clean.
- Fresh dev server: `og:url` count = 0, `og:image` still → `og.jpg`.

## After deploy

Share a **fresh** URL in a new LinkedIn post, e.g. `…/series/offline-first-kmp?v=8`. With no `og:url` to canonicalize against, LinkedIn scrapes it as a new URL and renders the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)