### PR TITLE
Ignore major bumps for tailwindcss and typescript in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,18 @@ updates:
           - "@next/*"
           - "react"
           - "react-dom"
+    # Hold back two major upgrades that need a deliberate migration, not an
+    # auto-bump (both were build-tested and break `next build` as-is):
+    #  - tailwindcss 4.x: CSS-first config + PostCSS plugin moved to
+    #    @tailwindcss/postcss; needs a config/CSS rewrite.
+    #  - typescript 7.x: the native compiler port isn't yet compatible with
+    #    Next's build-time TypeScript integration.
+    # Minor/patch bumps within the current majors still come through.
+    ignore:
+      - dependency-name: "tailwindcss"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   # Keep the GitHub Actions used by the deploy and guard workflows current.
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Adds `ignore` rules to `.github/dependabot.yml` so Dependabot stops re-opening two major upgrades that were build-tested and break `next build` as auto-bumps:

- **tailwindcss 4.x** — CSS-first config + PostCSS plugin moved to `@tailwindcss/postcss`; needs a config/CSS rewrite (closed PR #32).
- **typescript 7.x** — native compiler port, not yet compatible with Next's build-time TypeScript integration (closed PR #33).

Scoped to `version-update:semver-major` only, so minor/patch bumps within the current majors (tailwind 3.x, typescript 6.x) still come through. Each major will be revisited as a deliberate migration PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)