### PR TITLE
Bump js-yaml to 3.15.1 (fix CVE-2026-59870)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "typescript": "^6.0.2"
   },
   "resolutions": {
-    "js-yaml": "^3.15.0",
+    "js-yaml": "^3.15.1",
     "postcss": "^8.5.18",
     "sharp": "^0.35.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -752,10 +752,10 @@ is-plain-obj@^4.0.0:
   resolved "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz"
   integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
 
-js-yaml@^3.13.1, js-yaml@^3.15.0:
-  version "3.15.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.0.tgz#586e5214eafe3e893756a41e979b50d89d3e4a67"
-  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
+js-yaml@^3.13.1, js-yaml@^3.15.1:
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.1.tgz#24bc95028f361cdaaa84745b06a109c4486773c0"
+  integrity sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
Resolves Dependabot alert #272 — `GHSA-5p4m-2wfm-xmqj` / **CVE-2026-59870** (high): quadratic CPU consumption in js-yaml `!!omap` resolution.

## Change
- `resolutions.js-yaml`: `^3.15.0` → `^3.15.1`, lockfile refreshed. Single deduped `js-yaml@3.15.1` (was 3.15.0).

## Why it's safe
- Patch-level bump within the 3.x line.
- Only two constraints in the tree — gray-matter's `^3.13.1` and this resolution — both allow 3.15.1. Nothing caps it below.
- `yarn typecheck` ✅ and `yarn build` ✅ (build exercises the gray-matter → js-yaml frontmatter path).

## Exposure note
js-yaml only parses author-controlled frontmatter at build time here — no untrusted-YAML runtime path — so real-world risk is low. This clears the alert and keeps the tree clean.

## Relationship to other open dep PRs
Independent of #39, #44, #45 — none of them bump js-yaml (#45 grouped it in but left it at 3.15.0). Note: #39 and #45 also touch `package.json`/`yarn.lock`, so whichever merges after this one will need a lockfile rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)