### PR TITLE
Bump postcss (fix #273) + set Dependabot to security-only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    # Security-only: 0 disables routine version-update PRs, but Dependabot
+    # security updates (CVE fixes) still open regardless of this limit. We
+    # apply version bumps deliberately rather than on a schedule.
+    open-pull-requests-limit: 0
     # Collapse routine bumps into a few PRs instead of one per package.
     groups:
       next:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "resolutions": {
     "js-yaml": "^3.15.1",
-    "postcss": "^8.5.18",
+    "postcss": "^8.5.23",
     "sharp": "^0.35.0"
   },
   "devDependencies": {
@@ -29,7 +29,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "autoprefixer": "^10.4.7",
-    "postcss": "^8.5.18",
+    "postcss": "^8.5.23",
     "tailwindcss": "^3.1.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1074,10 +1074,10 @@ ms@2.1.2:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-nanoid@^3.3.16:
-  version "3.3.16"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
-  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
+nanoid@^3.3.17:
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 next@^16.2.12:
   version "16.2.12"
@@ -1195,12 +1195,12 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.4.31, postcss@^8.4.18, postcss@^8.5.18:
-  version "8.5.22"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.22.tgz#086a0d5685a715acf5950ebbcb1538faf3051697"
-  integrity sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==
+postcss@8.4.31, postcss@^8.4.18, postcss@^8.5.23:
+  version "8.5.26"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.26.tgz#6e75135780c7e10df3433bf2266c552d35c8c620"
+  integrity sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==
   dependencies:
-    nanoid "^3.3.16"
+    nanoid "^3.3.17"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 


### PR DESCRIPTION
Dependency hygiene — closes out the remaining open security alert and stops routine Dependabot noise.

## Changes
1. **postcss `^8.5.18` → `^8.5.23`** (resolution + devDependency; resolves to 8.5.26). Fixes Dependabot alert #273 — `GHSA-fxqj-rqcc-2cmp` (medium): attacker-controlled `sourceMappingURL` reads arbitrary `.map` files when `from` is unset. Patch-level bump within 8.5.x.
2. **`dependabot.yml`: npm `open-pull-requests-limit: 0`.** Disables routine version-update PRs; **security updates still open regardless** of this limit. Version bumps are applied deliberately from now on.

## Verification
- `yarn typecheck` ✅
- `yarn build` ✅ (postcss sits in the Tailwind/autoprefixer build path — exercised)

## Follow-up (outside this PR)
Supersedes the routine Dependabot PRs #39, #44, #45 — none carry a security fix (#45 grouped postcss in but left it at the vulnerable 8.5.22). Closing those separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)